### PR TITLE
Change how we format repl output in comments so IntelliJ doesn't highlight those lines.

### DIFF
--- a/src/main/scala/introcourse/level01/IntroExercises.scala
+++ b/src/main/scala/introcourse/level01/IntroExercises.scala
@@ -16,7 +16,7 @@ object IntroExercises {
     * You must specify the types of the inputs but the output return type is optional
     * and can be inferred by the compiler.
     * scala> add(1, 2)
-    * = 3
+    * > 3
     **/
   def add(x: Int, y: Int): Int = ???
 
@@ -24,7 +24,7 @@ object IntroExercises {
   /**
     * Let's write the curried version of the `add` function defined previously
     * scala> addCurried(1)(2)
-    * = 3
+    * > 3
     **/
   def addCurried(x: Int)(y: Int): Int = ???
 
@@ -32,7 +32,7 @@ object IntroExercises {
   /**
     * Reuse the `addCurried` function and partially apply it for adding 5 to anything.
     * scala> add5(4)
-    * = 9
+    * > 9
     *
     **/
   def add5(x: Int): Int = {
@@ -61,9 +61,9 @@ object IntroExercises {
 
   /**
     * scala> timesTwoIfEven(4)
-    * = 8
+    * > 8
     * scala> timesTwoIfEven(3)
-    * = 3
+    * > 3
     *
     * Important: Every `if` must have an `else`! Otherwise your function is not total.
     */
@@ -71,7 +71,7 @@ object IntroExercises {
 
   /**
     * scala> showNumber(100)
-    * = "The number is 100"
+    * > "The number is 100"
     *
     * Hint: Use string interpolation, e.g. s"$x"
     */

--- a/src/main/scala/introcourse/level02/TypesExercises.scala
+++ b/src/main/scala/introcourse/level02/TypesExercises.scala
@@ -37,7 +37,7 @@ object TypesExercises {
   /**
     * scala> val person = Person("Bob", 50)
     * scala> showPerson1(person)
-    * = "Bob is 50 years old"
+    * > "Bob is 50 years old"
     *
     * This uses a technique called pattern matching. You will see more of this later.
     *
@@ -63,7 +63,7 @@ object TypesExercises {
   /**
     * scala> val person = Person("Bob", 50)
     * scala> changeName("Bobby", person)
-    * = Person("Bobby", 50)
+    * > Person("Bobby", 50)
     *
     * `person` is immutable! This function returns a new instance of `Person` with the `name` changed.
     * Check out the corresponding test in `TypesExercisesTest` to understand why.
@@ -89,7 +89,7 @@ object TypesExercises {
   /**
     * scala> val wallet = Wallet(20.5)
     * scala> showWallet(wallet)
-    * = "The wallet amount is 20.5"
+    * > "The wallet amount is 20.5"
     *
     * You can solve this like how you solved `showPerson1` or `showPerson2`.
     */
@@ -100,7 +100,7 @@ object TypesExercises {
     *
     * scala> val wallet = Wallet(100)
     * scala> purchase(80, wallet)
-    * = Wallet(20)
+    * > Wallet(20)
     *
     * Hint: You need to calculate the new amount first.
     **/
@@ -114,13 +114,13 @@ object TypesExercises {
 
   /**
     * scala> showTrafficLightStr("red")
-    * = "The traffic light is red"
+    * > "The traffic light is red"
     *
     * scala> showTrafficLightStr("yellow")
-    * = "The traffic light is yellow"
+    * > "The traffic light is yellow"
     *
     * scala> showTrafficLightStr("green")
-    * = "The traffic light is green"
+    * > "The traffic light is green"
     *
     * What if `trafficLight` is not "red", "yellow" or "green"?
     *
@@ -158,7 +158,7 @@ object TypesExercises {
     *
     *
     * scala> showTrafficLightStr("flashing")
-    * = "The traffic light is flashing"
+    * > "The traffic light is flashing"
     *
     **/
 
@@ -187,13 +187,13 @@ object TypesExercises {
 
   /**
     * scala> showTrafficLight(Red)
-    * = "The traffic light is red"
+    * > "The traffic light is red"
     *
     * scala> showTrafficLight(Yellow)
-    * = "The traffic light is yellow"
+    * > "The traffic light is yellow"
     *
     * scala> showTrafficLight(Green)
-    * = "The traffic light is green"
+    * > "The traffic light is green"
     *
     * It is impossible to get an invalid TrafficLight as input
     *

--- a/src/main/scala/introcourse/level03/ListExercises.scala
+++ b/src/main/scala/introcourse/level03/ListExercises.scala
@@ -16,13 +16,13 @@ object ListExercises {
     * You can create a List using the `::` constructor as such:
     *
     * scala> `::`(1, `::`(2, `::`(3, Nil))) // backticks to use :: in prefix position
-    * = List(1, 2, 3)
+    * > List(1, 2, 3)
     *
     * scala> (1 :: (2 :: (3 :: Nil))) // no need for backticks to use :: in infix position
-    * = List(1, 2, 3)
+    * > List(1, 2, 3)
     *
     * scala> 1 :: 2 :: 3 :: Nil
-    * = List(1, 2, 3)
+    * > List(1, 2, 3)
     *
     * Often times, the `List.apply` static method is more convenient:
     *
@@ -35,7 +35,7 @@ object ListExercises {
 
   /**
     * scala> prependToList(1, List(2, 3, 4))
-    * = List(1,2,3,4)
+    * > List(1,2,3,4)
     *
     * Hint: Refer the construction of list
     */
@@ -43,7 +43,7 @@ object ListExercises {
 
   /**
     * scala> appendToList(1, List(2, 3, 4))
-    * = List(2,3,4,1)
+    * > List(2,3,4,1)
     *
     * Hint: Use the :+ operator
     */
@@ -55,10 +55,10 @@ object ListExercises {
     * For this exercise, let's build a version of `isEmpty` called `isEmptyList` without using `.isEmpty` (that would be cheating!).
     *
     * scala> isEmptyList(Nil)
-    * = true
+    * > true
     *
     * scala> isEmptyList(List(1, 2, 3))
-    * = false
+    * > false
     *
     * Hint: Use pattern matching. You can pattern match on `List` using its two constructors `::` and `Nil` as such:
     *
@@ -73,13 +73,13 @@ object ListExercises {
 
   /**
     * scala> showListSize(List(1, 2, 3))
-    * = "This is a list of size 3"
+    * > "This is a list of size 3"
     *
     * scala> showListSize(List("ABC"))
-    * = "This is a list of size 1"
+    * > "This is a list of size 1"
     *
     * scala> showListSize(Nil)
-    * = "This is an empty list"
+    * > "This is an empty list"
     *
     * Hint: Use pattern matching, string interpolation and length
     */
@@ -92,7 +92,7 @@ object ListExercises {
     * are of the same size.
     *
     * scala> addNumToEach(10, List(1, 2, 3))
-    * = List(11, 12, 13)
+    * > List(11, 12, 13)
     *
     * Hint: Use .map
     **/
@@ -104,7 +104,7 @@ object ListExercises {
     * This is typically what you want if the size of the resulting List is <= that of the initial.
     *
     * scala> filterEven(List(1, 2, 3, 4))
-    * = List(2, 4)
+    * > List(2, 4)
     *
     * Hint: Use .filter and '%' for mod operator
     */
@@ -124,11 +124,11 @@ object ListExercises {
 
   /**
     * scala> product(List(2, 5, 3))
-    * = 30
+    * > 30
     *
     * https://en.wikipedia.org/wiki/Empty_product
     * scala> product(Nil)
-    * = 1
+    * > 1
     *
     * Hint: Use .foldLeft
     */
@@ -136,10 +136,10 @@ object ListExercises {
 
   /**
     * scala> min(List(4, 6, 1))
-    * = 1
+    * > 1
     *
     * scala> min(Nil)
-    * = Int.MinValue
+    * > Int.MinValue
     *
     * Hint: Use pattern matching and .foldLeft
     **/
@@ -163,10 +163,10 @@ object ListExercises {
     * return the first one.
     *
     * scala> youngestPerson(peopleList)
-    * = Person("Karen Page", 27)
+    * > Person("Karen Page", 27)
     *
     * scala> youngestPerson(Nil)
-    * = Person("Nobody", 0)
+    * > Person("Nobody", 0)
     *
     * Hint: Use pattern matching and .foldLeft
     */
@@ -198,7 +198,7 @@ object ListExercises {
     * Log every nth person from the `peopleList` given an index `n`.
     *
     * scala> showEveryNthPerson(2, peopleList)
-    * = List("Karen Page is 27 years old", "Claire Temple is 32 years old", "Elektra Natchios is 27 years old")
+    * > List("Karen Page is 27 years old", "Claire Temple is 32 years old", "Elektra Natchios is 27 years old")
     *
     * Validation rules:
     *

--- a/src/main/scala/introcourse/level04/NullExercises.scala
+++ b/src/main/scala/introcourse/level04/NullExercises.scala
@@ -19,16 +19,16 @@ object NullExercises {
     * If given an unrecognised value, return `null`.
     *
     * scala> mkTrafficLightOrNull("red")
-    * = Red
+    * > Red
     *
     * scala> mkTrafficLightOrNull("green")
-    * = Green
+    * > Green
     *
     * scala> mkTrafficLightOrNull("yellow")
-    * = Yellow
+    * > Yellow
     *
     * scala> mkTrafficLightOrNull("bob")
-    * = null
+    * > null
     **/
   def mkTrafficLightOrNull(str: String): TrafficLight =
     str match {
@@ -42,16 +42,16 @@ object NullExercises {
     * Write a function that calls `mkTrafficLightOrNull` and then turn each `TrafficLight` into a readable `String`.
     *
     * scala> mkTrafficLightOrNullThenShow("red")
-    * = "Traffic light is red"
+    * > "Traffic light is red"
     *
     * scala> mkTrafficLightOrNullThenShow("green")
-    * = "Traffic light is green"
+    * > "Traffic light is green"
     *
     * scala> mkTrafficLightOrNullThenShow("yellow")
-    * = "Traffic light is yellow"
+    * > "Traffic light is yellow"
     *
     * scala> mkTrafficLightOrNullThenShow("bob")
-    * = "Traffic light is invalid"
+    * > "Traffic light is invalid"
     *
     * Hint: Use `mkTrafficLightOrNull` and pattern matching
     */
@@ -62,29 +62,29 @@ object NullExercises {
     * If the `name` and `age` are invalid (as described below), return `null`.
     *
     * scala> mkPersonOrNull("Bob", 20)
-    * = Person("Bob", 20)
+    * > Person("Bob", 20)
     *
     * If `name` is blank:
     *
     * scala> mkPersonOrNull("", 20)
-    * = null
+    * > null
     *
     * If `age` < 0:
     *
     * scala> mkPersonOrNull("Bob", -1)
-    * = null
+    * > null
     **/
   def mkPersonOrNull(name: String, age: Int): Person = ???
 
   /**
     * scala> mkPersonOrNullThenChangeName("Bob", 20, "John")
-    * = Person("John", 20)
+    * > Person("John", 20)
     *
     * scala> mkPersonOrNullThenChangeName("Bob", -1, "John")
-    * = null
+    * > null
     *
     * scala> mkPersonOrNullThenChangeName("Bob", 20, "")
-    * = null
+    * > null
     *
     * Hint: Use `mkPersonOrNull` and `changeName` (already implemented below)
     **/

--- a/src/main/scala/introcourse/level04/OptionExercises1.scala
+++ b/src/main/scala/introcourse/level04/OptionExercises1.scala
@@ -17,23 +17,23 @@ object OptionExercises1 {
 
   /**
     * scala> safeMean(List(1, 2, 10))
-    * = Some(4.333333333333333)
+    * > Some(4.333333333333333)
     *
     * scala> safeMean(Nil)
-    * = None
+    * > None
     *
     * Hint: Use `sum`, `length` and convert the numerator or denominator to a `Double` using `toDouble`
     *
     * If you do division on two `Int`s, you will get an `Int` back, which is often not what you want!
     *
     * scala> 5 / 2
-    * = 2
+    * > 2
     *
     * scala> 5.toDouble / 2
-    * = 2.5
+    * > 2.5
     *
     * scala> 5 / 2.toDouble
-    * = 2.5
+    * > 2.5
     **/
   def safeMean(nums: List[Int]): Option[Double] = ???
 
@@ -45,16 +45,16 @@ object OptionExercises1 {
 
   /**
     * scala> mkTrafficLight("red")
-    * = Some(Red)
+    * > Some(Red)
     *
     * scala> mkTrafficLight("green")
-    * = Some(Green)
+    * > Some(Green)
     *
     * scala> mkTrafficLight("yellow")
-    * = Some(Yellow)
+    * > Some(Yellow)
     *
     * scala> mkTrafficLight("bob")
-    * = None
+    * > None
     *
     * Hint: Use pattern matching
     **/
@@ -62,16 +62,16 @@ object OptionExercises1 {
 
   /**
     * scala> mkTrafficLightThenShow("red")
-    * = "Traffic light is red"
+    * > "Traffic light is red"
     *
     * scala> mkTrafficLightThenShow("green")
-    * = "Traffic light is green"
+    * > "Traffic light is green"
     *
     * scala> mkTrafficLightThenShow("yellow")
-    * = "Traffic light is yellow"
+    * > "Traffic light is yellow"
     *
     * scala> mkTrafficLightThenShow("bob")
-    * = "Traffic light `bob` is invalid"
+    * > "Traffic light `bob` is invalid"
     *
     * Hint: Use `mkTrafficLight` then pattern match.
     *
@@ -88,17 +88,17 @@ object OptionExercises1 {
 
   /**
     * scala> mkPerson("Bob", 20)
-    * = Some(Person("Bob", 20))
+    * > Some(Person("Bob", 20))
     *
     * If `name` is blank:
     *
     * scala> mkPerson("", 20)
-    * = None
+    * > None
     *
     * If `age` < 0:
     *
     * scala> mkPerson("Bob", -1)
-    * = None
+    * > None
     *
     * Hint: Don't forget every if needs an else!
     **/
@@ -106,13 +106,13 @@ object OptionExercises1 {
 
   /**
     * scala> mkPersonThenChangeName("Bob", 20, "John")
-    * = Some(Person("John", 20))
+    * > Some(Person("John", 20))
     *
     * scala> mkPersonThenChangeName("Bob", -1, "John")
-    * = None
+    * > None
     *
     * scala> mkPersonThenChangeName("Bob", 20, "")
-    * = None
+    * > None
     *
     * Hint: Use `mkPerson` and pattern matching
     **/

--- a/src/main/scala/introcourse/level04/OptionExercises2.scala
+++ b/src/main/scala/introcourse/level04/OptionExercises2.scala
@@ -32,10 +32,10 @@ object OptionExercises2 {
 
   /**
     * scala> findHumanById(1)
-    * = Some(Human("Sally", None))
+    * > Some(Human("Sally", None))
     *
     * scala> findHumanById(100)
-    * = None
+    * > None
     *
     * Hint: Use `get` method on `humansDatabase` Map
     **/
@@ -43,10 +43,10 @@ object OptionExercises2 {
 
   /**
     * scala> findJobById(1)
-    * = Some(Job("Teacher", "Expert in their field"))
+    * > Some(Job("Teacher", "Expert in their field"))
     *
     * scala> findJobById(100)
-    * = None
+    * > None
     *
     * Hint: Use `get` method on `jobsDatabase` Map
     **/
@@ -54,10 +54,10 @@ object OptionExercises2 {
 
   /**
     * scala> findJobDescriptionGivenJobId1(1)
-    * = Some("Expert in their field")
+    * > Some("Expert in their field")
     *
     * scala> findJobDescriptionGivenJobId1(100)
-    * = None
+    * > None
     *
     * Hint: Use `findJobById` and then pattern match
     */
@@ -86,10 +86,10 @@ object OptionExercises2 {
 
   /**
     * scala> findJobDescriptionGivenJobIdOrElse1(1)
-    * = "Expert in their field"
+    * > "Expert in their field"
     *
     * scala> findJobDescriptionGivenJobIdOrElse1(100)
-    * = "Job with id 100 does not exist"
+    * > "Job with id 100 does not exist"
     *
     * Hint: Use `findJobDescriptionGivenJobId1` then pattern match
     */
@@ -102,10 +102,10 @@ object OptionExercises2 {
 
   /**
     * scala> findJobIdByHumanId(1)
-    * = None
+    * > None
     *
     * scala> findJobIdByHumanId(2)
-    * = Some(1)
+    * > Some(1)
     *
     * Hint: Use `findHumanById` and try `map`, `flatten`
     *
@@ -115,7 +115,7 @@ object OptionExercises2 {
 
   /**
     * scala> findJobByHumanId(2)
-    * = Some(Job("Teacher", "Expert in their field"))
+    * > Some(Job("Teacher", "Expert in their field"))
     *
     * Hint: Use `findJobIdByHumanId` and `findJobById`
     */
@@ -125,10 +125,10 @@ object OptionExercises2 {
     * Find the name of the `Job` that this `humanId` has
     *
     * scala> findJobNameByHumanId(2)
-    * = Some("Teacher")
+    * > Some("Teacher")
     *
     * scala> findJobNameByHumanId(1)
-    * = None
+    * > None
     *
     * Hint: Use `findJobByHumanId`
     */

--- a/src/main/scala/introcourse/level04/OptionExercises3.scala
+++ b/src/main/scala/introcourse/level04/OptionExercises3.scala
@@ -12,10 +12,10 @@ object OptionExercises3 {
     * Rewrite this function using for-comprehension syntax.
     *
     * scala> findJobIdByHumanIdUsingFor(1)
-    * = None
+    * > None
     *
     * scala> findJobIdByHumanIdUsingFor(2)
-    * = Some(1)
+    * > Some(1)
     */
   def findJobIdByHumanIdUsingFor(humanId: HumanId): Option[JobId] =
     findHumanById(humanId).flatMap(human => human.optJobId)
@@ -24,7 +24,7 @@ object OptionExercises3 {
     * Rewrite this function using for-comprehension syntax.
     *
     * scala> findJobByHumanIdUsingFor(2)
-    * = Some(Job("Teacher", "Expert in their field"))
+    * > Some(Job("Teacher", "Expert in their field"))
     */
   def findJobByHumanIdUsingFor(humanId: HumanId): Option[Job] =
     findJobIdByHumanId(humanId).flatMap(jobId => findJobById(jobId))
@@ -33,10 +33,10 @@ object OptionExercises3 {
     * Rewrite this function using for-comprehension syntax.
     *
     * scala> findJobNameByHumanIdUsingFor(2)
-    * = Some("Teacher")
+    * > Some("Teacher")
     *
     * scala> findJobNameByHumanIdUsingFor(1)
-    * = None
+    * > None
     */
   def findJobNameByHumanIdUsingFor(humanId: HumanId): Option[String] =
     findJobByHumanId(humanId).map(job => job.name)

--- a/src/main/scala/introcourse/level05/EitherExercises.scala
+++ b/src/main/scala/introcourse/level05/EitherExercises.scala
@@ -48,10 +48,10 @@ object EitherExercises {
     * is empty or a Right if the supplied name is not empty.
     *
     * scala> getName("Fred")
-    * = Right(Fred)
+    * > Right(Fred)
     *
     * scala> getName("")
-    * = Left(EmptyName)
+    * > Left(EmptyName)
     **/
   def getName(providedName: String): Either[AppError, String] = ???
 
@@ -61,13 +61,13 @@ object EitherExercises {
     * and returns a Right with an Int age if the age is valid.
     *
     * scala> getAge("20")
-    * = Right(20)
+    * > Right(20)
     *
     * scala> getAge("Fred")
-    * = Left(InvalidAgeValue(Fred))
+    * > Left(InvalidAgeValue(Fred))
     *
     * scala> getAge("-1")
-    * = Left(InvalidAgeRange(-1))
+    * > Left(InvalidAgeRange(-1))
     *
     * Hint: use the toInt method to convert a String to an Int.
     */
@@ -83,16 +83,16 @@ object EitherExercises {
     * if the name and age are valid or returns a Left of AppError if either the name or age is invalid.
     *
     * scala> createPerson("Fred", "32")
-    * = Right(Person(Fred,32))
+    * > Right(Person(Fred,32))
     *
     * scala> createPerson("", "32")
-    * = Left(EmptyName)
+    * > Left(EmptyName)
     *
     * scala> createPerson("Fred", "ThirtyTwo")
-    * = Left(InvalidAgeValue(ThirtyTwo))
+    * > Left(InvalidAgeValue(ThirtyTwo))
     *
     * scala> createPerson("Fred", "150")
-    * = Left(InvalidAgeRange(150))
+    * > Left(InvalidAgeRange(150))
     *
     * Hint: Use a for-comprehension to sequence the Eithers from getName and getAge
     */
@@ -105,16 +105,16 @@ object EitherExercises {
 
   /**
     * scala> makeNameUpperCase("Fred", "32")
-    * = Right(Person(FRED,32))
+    * > Right(Person(FRED,32))
     *
     * scala> makeNameUpperCase("", "32")
-    * = Left(EmptyName)
+    * > Left(EmptyName)
     *
     * scala> makeNameUpperCase("Fred", "ThirtyTwo")
-    * = Left(InvalidAgeValue(ThirtyTwo))
+    * > Left(InvalidAgeValue(ThirtyTwo))
     *
     * scala> makeNameUpperCase("Fred", "150")
-    * = Left(InvalidAgeRange(150))
+    * > Left(InvalidAgeRange(150))
     *
     * Hint: Use `createPerson` then use `map` and `copy`.
     *
@@ -127,16 +127,16 @@ object EitherExercises {
     * function as the end of the world for our application, where we are providing feedback to the user on their input.
     *
     * scala> createPersonAndShow("Fred", "32")
-    * = "Fred is 32"
+    * > "Fred is 32"
     *
     * scala> createPersonAndShow("", "32")
-    * = "Empty name supplied"
+    * > "Empty name supplied"
     *
     * scala> createPersonAndShow("Fred", "ThirtyTwo")
-    * = "Invalid age value supplied: ThirtyTwo"
+    * > "Invalid age value supplied: ThirtyTwo"
     *
     * scala> createPersonAndShow("Fred", "150")
-    * = "Provided age must be between 1-120: 150"
+    * > "Provided age must be between 1-120: 150"
     *
     * Hint: Use `createPerson` then pattern match.
     *
@@ -156,7 +156,7 @@ object EitherExercises {
     * to create a List of Person instances.
     *
     * scala> createValidPeople
-    * = List(Person(Tokyo, 30), Person(Berlin, 43))
+    * > List(Person(Tokyo, 30), Person(Berlin, 43))
     *
     * Hint: Use `map` and `collect`
     *
@@ -168,7 +168,7 @@ object EitherExercises {
     * that occur while processing personStringPairs.
     *
     * scala> collectErrors
-    * = List(InvalidAgeValue(provided age is invalid: 5o),
+    * > List(InvalidAgeValue(provided age is invalid: 5o),
     * InvalidAgeRange(provided age should be between 1-120: 200),
     * InvalidAgeRange(provided age should be between 1-120: 0),
     * EmptyName(provided name is empty))

--- a/src/main/scala/introcourse/level05/ExceptionExercises.scala
+++ b/src/main/scala/introcourse/level05/ExceptionExercises.scala
@@ -36,10 +36,10 @@ object ExceptionExercises {
     * is empty.
     *
     * scala> getName("Fred")
-    * = "Fred"
+    * > "Fred"
     *
     * scala> getName("")
-    * = EmptyNameException: provided name is empty
+    * > EmptyNameException: provided name is empty
     *
     * Hint: use the isEmpty method on String
     */
@@ -52,13 +52,13 @@ object ExceptionExercises {
     * If the provided age is not between 1 and 120 throw an InvalidAgeRangeException.
     *
     * scala> getAge("Fred")
-    * = InvalidAgeValueException: provided age is invalid: Fred
+    * > InvalidAgeValueException: provided age is invalid: Fred
     *
     * scala> getAge("20")
-    * = 20
+    * > 20
     *
     * scala> getAge("0")
-    * = InvalidAgeRangeException: provided age should be between 1-120: 0
+    * > InvalidAgeRangeException: provided age should be between 1-120: 0
     *
     * Hint: use the toInt method to convert a String to an Int.
     */
@@ -79,16 +79,16 @@ object ExceptionExercises {
     * What does this imply?
     *
     * scala> createPerson("Fred", "32")
-    * = "Person(Fred, 32)"
+    * > "Person(Fred, 32)"
     *
     * scala> createPerson("", "32")
-    * = EmptyNameException: provided name is empty
+    * > EmptyNameException: provided name is empty
     *
     * scala> createPerson("Fred", "ThirtyTwo")
-    * = InvalidAgeValueException: provided age is invalid: ThirtyTwo
+    * > InvalidAgeValueException: provided age is invalid: ThirtyTwo
     *
     * scala> createPerson("Fred", "150")
-    * = InvalidAgeRangeException: provided age should be between 1-120: 150
+    * > InvalidAgeRangeException: provided age should be between 1-120: 150
     *
     * Hint: Use `getName` and `getAge` from above.
     */
@@ -100,7 +100,7 @@ object ExceptionExercises {
     * It should only catch Exceptions thrown by createPerson.
     *
     * scala> createValidPeople
-    * = List(Person("Tokyo", 30), Person("Berlin", 43))
+    * > List(Person("Tokyo", 30), Person("Berlin", 43))
     *
     * Hint: Use `map` and `collect`
     *
@@ -124,7 +124,7 @@ object ExceptionExercises {
     * It should only catch Exceptions thrown by createPerson.
     *
     * scala> collectErrors
-    * = List(InvalidAgeValueException: provided age is invalid: 5o,
+    * > List(InvalidAgeValueException: provided age is invalid: 5o,
     *        InvalidAgeRangeException: provided age should be between 1-120: 200,
     *        InvalidAgeRangeException: provided age should be between 1-120: 0,
     *        EmptyNameException: provided name is empty)

--- a/src/main/scala/introcourse/level06/TryExercises.scala
+++ b/src/main/scala/introcourse/level06/TryExercises.scala
@@ -38,10 +38,10 @@ object TryExercises {
     * ```
     *
     * scala> parseIntSafe("1")
-    * = Success(1)
+    * > Success(1)
     *
     * scala> parseIntSafe("abc")
-    * = Failure(java.lang.NumberFormatException: For input string: "abc")
+    * > Failure(java.lang.NumberFormatException: For input string: "abc")
     *
     * Hint: Use `Try` and `parseInt`
     */
@@ -49,10 +49,10 @@ object TryExercises {
 
   /**
     * scala> parseBooleanSafe("true")
-    * = Success(true)
+    * > Success(true)
     *
     * scala> parseBooleanSafe("abc")
-    * = Failure(java.lang.IllegalArgumentException: For input string: "abc")
+    * > Failure(java.lang.IllegalArgumentException: For input string: "abc")
     *
     * Hint: Use .toBoolean to convert a String to a Boolean
     **/
@@ -61,10 +61,10 @@ object TryExercises {
 
   /**
     * scala> increment("10")
-    * = Success(11)
+    * > Success(11)
     *
     * scala> increment("NaN")
-    * = Failure(java.lang.NumberFormatException: For input string: "NaN")
+    * > Failure(java.lang.NumberFormatException: For input string: "NaN")
     *
     * Hint: Use `parseIntSafe` and solve it without using pattern matching
     */
@@ -90,9 +90,9 @@ object TryExercises {
     * Write a function that converts a `Try[A]` to `Option[A]`.
     *
     * scala> tryToOption(parseIntSafe("1"))
-    * = Some(1)
+    * > Some(1)
     * scala> tryToOption(parseIntSafe("abc"))
-    * = None
+    * > None
     */
   def tryToOption[A](tryA: Try[A]): Option[A] =
     tryA match {
@@ -117,16 +117,16 @@ object TryExercises {
     * Create a CSV parser to safely create an Employee
     *
     * scala> mkEmployee("Bob,22,true")
-    * = Right(Employee("Bob", 22, true))
+    * > Right(Employee("Bob", 22, true))
     *
     * scala> mkEmployee("Bob,abc,true")
-    * = Left(TryError(For input string: "abc"))
+    * > Left(TryError(For input string: "abc"))
     *
     * scala> mkEmployee("Bob,22,abc")
-    * = Left(TryError(For input string: "abc"))
+    * > Left(TryError(For input string: "abc"))
     *
     * scala> mkEmployee("Bob,22")
-    * = Left(TryError(CSV has wrong number of fields. Expected 3.))
+    * > Left(TryError(CSV has wrong number of fields. Expected 3.))
     *
     * Hint: Use `parseIntSafe`, `parseBooleanSafe`, for-comprehension, `tryToEither`
     */

--- a/src/main/scala/introcourse/level07/LogParser.scala
+++ b/src/main/scala/introcourse/level07/LogParser.scala
@@ -63,13 +63,13 @@ object LogParser {
     * Define a function to parse an individual log message.
     *
     * scala> parseLog("I,147,mice in the air")
-    * = KnownLog(Info, 147, "mice in the air")
+    * > KnownLog(Info, 147, "mice in the air")
     *
     * scala> parseLog("E,2,148,weird")
-    * = KnownLog(Error(2), 148, "weird")
+    * > KnownLog(Error(2), 148, "weird")
     *
     * scala> parseLog("X blblbaaaaa")
-    * = UnknownLog("X blblbaaaaa")
+    * > UnknownLog("X blblbaaaaa")
     *
     * Here is the beginning of one possible approach.
     **/
@@ -87,7 +87,7 @@ object LogParser {
 
   /**
     * scala> parseLogFile("I,147,mice in the air\nX blblbaaaaa")
-    * = List(KnownLog(Info, 147, "mice in the air"), UnknownLog("X blblbaaaaa"))
+    * > List(KnownLog(Info, 147, "mice in the air"), UnknownLog("X blblbaaaaa"))
     *
     * Hint: Use `parseLog`
     * Hint: Convert an Array to a List with .toList
@@ -100,10 +100,10 @@ object LogParser {
     * It should not return any log that is not an error.
     *
     * scala> getErrorsOverSeverity(List(KnownLog(Error(2), 123, some error msg"), UnknownLog("blblbaaaaa")), 1)
-    * = List(KnownLog(Error(2), 123, some error msg"))
+    * > List(KnownLog(Error(2), 123, some error msg"))
     *
     * scala> getErrorsOverSeverity(List(KnownLog(Error(2), 123, some error msg")), 2)
-    * = List()
+    * > List()
     **/
   def getErrorsOverSeverity(logs: List[LogMessage], minimumSeverity: Int): List[LogMessage] = ???
 
@@ -111,13 +111,13 @@ object LogParser {
     * Write a function to convert a `LogMessage` to a readable `String`.
     *
     * scala> showLogMessage(KnownLog(Info, 147, "mice in the air"))
-    * = "Info (147) mice in the air"
+    * > "Info (147) mice in the air"
     *
     * scala> showLogMessage(KnownLog(Error(2), 147, "weird"))
-    * = "Error 2 (147) weird"
+    * > "Error 2 (147) weird"
     *
     * scala> showLogMessage(UnknownLog("message"))
-    * = "Unknown log: message"
+    * > "Unknown log: message"
     *
     * Hint: Pattern match and use string interpolation
     **/
@@ -127,7 +127,7 @@ object LogParser {
     * Use `showLogMessage` on error logs with severity greater than the given `severity`.
     *
     * scala> showErrorsOverSeverity(logFile, 2)
-    * = List("Error 5 (158) some strange error")
+    * > List("Error 5 (158) some strange error")
     *
     * Hint: Use `parseLogFile`, `getErrorsOverSeverity` and `showLogMessage`
     **/


### PR DESCRIPTION
I don't know if you guys have seen this but by default IntelliJ's formatter goes crazy over those `* = ` lines.

Just changing them all to `* > `